### PR TITLE
Use byte string to detect reply newline character for Python3

### DIFF
--- a/xenavalkyrie/api/BaseSocket.py
+++ b/xenavalkyrie/api/BaseSocket.py
@@ -67,7 +67,7 @@ class BaseSocket:
 
         try:
             reply = self.sock.recv(4096)
-            while not reply.endswith('\x0a'):
+            while not reply.endswith(b'\x0a'):
                 reply += self.sock.recv(4096)
             if reply.find(b'---^') != -1 or reply.find(b'^---') != -1:
                 # read next line for actual message


### PR DESCRIPTION
When detecting the newline char comparison needs to be done with byte strong form compatibility with python3 (as already done for the finds on the next lines)